### PR TITLE
Hinzufügen von einer Validierung

### DIFF
--- a/VirtuellerZaehler/locale.json
+++ b/VirtuellerZaehler/locale.json
@@ -13,7 +13,8 @@
             "Accept value with confirmation": "Erfordere Bestätigung zum Übernehmen",
             "Confirm": "Bestätigen",
             "Cancel": "Abbrechen",
-            "The logging was activate":"Das Logging wurde aktiviert" 
+            "The logging was activate":"Das Logging wurde aktiviert" ,
+            "The value is not a number": "Der Wert ist keine Zahl"
         }
     }
 }

--- a/VirtuellerZaehler/module.php
+++ b/VirtuellerZaehler/module.php
@@ -25,6 +25,7 @@ class VirtuellerZaehler extends IPSModule
 
         //Register Variable
         $this->RegisterVariableFloat('CurrentCounterReading', $this->Translate('Current counter reading'));
+        //NewCounterReading is String, cause of a bug in the Webfront, there float is not every time set manually
         $this->RegisterVariableString('NewCounterReading', $this->Translate('New counter reading'), 'VZ.NewCounter');
         $this->EnableAction('NewCounterReading');
     }
@@ -88,7 +89,14 @@ class VirtuellerZaehler extends IPSModule
     public function WriteNewCounterValue()
     {
         $currentCounter = $this->GetValue('CurrentCounterReading');
-        $newCounter = floatval(str_replace(',', '.', $this->GetValue('NewCounterReading')));
+
+        $newCounter = str_replace(',', '.', $this->GetValue('NewCounterReading'));
+        if(!is_numeric($newCounter)){
+            echo $this->Translate('The value is not a number');
+            return;
+        }
+
+        $newCounter = floatval($newCounter);
 
         if ($newCounter < 0) {
             echo $this->Translate('The value is negative');


### PR DESCRIPTION
Hinzufügen von einer Überprüfung ob es eine Nummer ist oder nur Buchstaben, sowie ein Kommentar, dass momentan noch eine String statt eine Float-Variable genutzt wird. 

close https://github.com/symcon/modules/issues/202